### PR TITLE
Added config option for drop removal

### DIFF
--- a/src/main/java/arcaratus/bloodarsenal/ConfigHandler.java
+++ b/src/main/java/arcaratus/bloodarsenal/ConfigHandler.java
@@ -177,6 +177,8 @@ public class ConfigHandler
     {
         @Comment({ "Should be set to false when another mod adds in its own Ore-Dict glass shards" })
         public boolean doGlassShardsDrop = true;
+        @Comment({ "Determines if there is a chance dying to a glass sacrificial dagger or bleeding has the drops disappear." })
+        public boolean glassDeathCanRemoveDrops = true;
         @Comment({ "The max range for anything that uses raytracing (Ender Sigil, Lightning Sigil, etc.)" })
         @RangeDouble(min = 1, max = 256)
         public double rayTraceRange = 64;

--- a/src/main/java/arcaratus/bloodarsenal/util/handler/EventHandler.java
+++ b/src/main/java/arcaratus/bloodarsenal/util/handler/EventHandler.java
@@ -47,15 +47,18 @@ public class EventHandler
     @SubscribeEvent
     public void onLivingDrops(LivingDropsEvent event)
     {
-        DamageSource source = event.getSource();
-        Random random = new Random();
-
-        if (source instanceof DamageSourceGlass || source instanceof DamageSourceBleeding)
+        if (ConfigHandler.misc.glassDeathCanRemoveDrops)
         {
-            if (random.nextBoolean())
-                event.getDrops().clear();
-            else if (event.getDrops().size() > 0)
-                event.getDrops().remove(random.nextInt(event.getDrops().size()));
+            DamageSource source = event.getSource();
+            Random random = new Random();
+
+            if (source instanceof DamageSourceGlass || source instanceof DamageSourceBleeding)
+            {
+                if (random.nextBoolean())
+                    event.getDrops().clear();
+                else if (event.getDrops().size() > 0)
+                    event.getDrops().remove(random.nextInt(event.getDrops().size()));
+            }
         }
     }
 


### PR DESCRIPTION
Defaults the config option to the current effect of true, but makes it so that the chance of inventory being cleared on death can be disabled entirely.