### PR TITLE
Switch from deprecated GuideAPI Book to BookBinder

### DIFF
--- a/src/main/java/arcaratus/bloodarsenal/compat/guideapi/GuideBloodArsenal.java
+++ b/src/main/java/arcaratus/bloodarsenal/compat/guideapi/GuideBloodArsenal.java
@@ -4,6 +4,7 @@ import WayofTime.bloodmagic.block.BlockLifeEssence;
 import WayofTime.bloodmagic.core.RegistrarBloodMagicItems;
 import amerifrance.guideapi.api.*;
 import amerifrance.guideapi.api.impl.Book;
+import amerifrance.guideapi.api.impl.BookBinder;
 import amerifrance.guideapi.category.CategoryItemStack;
 import arcaratus.bloodarsenal.BloodArsenal;
 import arcaratus.bloodarsenal.compat.guideapi.book.CategoryLifebringer;
@@ -24,38 +25,23 @@ import java.awt.*;
 @GuideBook(priority = EventPriority.HIGHEST)
 public class GuideBloodArsenal implements IGuideBook
 {
-    public static final Book GUIDE_BOOK = new Book();
-
     @Nullable
     @Override
     public Book buildBook()
     {
-        GUIDE_BOOK.setTitle("guide.bloodarsenal.title");
-        GUIDE_BOOK.setDisplayName("guide.bloodarsenal.display");
-        GUIDE_BOOK.setWelcomeMessage("guide.bloodarsenal.welcome");
-        GUIDE_BOOK.setAuthor("guide.bloodarsenal.author");
-        GUIDE_BOOK.setRegistryName(new ResourceLocation(BloodArsenal.MOD_ID, "guide"));
-        GUIDE_BOOK.setColor(new Color(119, 0, 0));
-
-        return GUIDE_BOOK;
-    }
-
-//    @Override
-//    public void handleModel(ItemStack bookStack)
-//    {
-//        GuideAPI.setModel(GUIDE_BOOK);
-//    }
-
-    @Override
-    public void handlePost(ItemStack bookStack)
-    {
-        String keyBase = "guide.bloodarsenal.category.";
-        GUIDE_BOOK.addCategory(new CategoryItemStack(CategoryLifebringer.buildCategory(), keyBase + "lifebringer", EnumBaseTypes.BLOOD_INFUSED_IRON_INGOT.getStack()));
+        BookBinder binder = new BookBinder(new ResourceLocation(BloodArsenal.MOD_ID, "guide"));
+        binder.setGuideTitle("guide.bloodarsenal.title");
+        binder.setItemName("guide.bloodarsenal.display");
+        binder.setHeader("guide.bloodarsenal.welcome");
+        binder.setAuthor("guide.bloodarsenal.author");
+        binder.setColor(new Color(119, 0, 0));
+        binder.addCategory(new CategoryItemStack(CategoryLifebringer.buildCategory(), "guide.bloodarsenal.category.lifebringer", EnumBaseTypes.BLOOD_INFUSED_IRON_INGOT.getStack()));
+        return binder.build();
     }
 
     @Override
     public IRecipe getRecipe(@Nonnull ItemStack bookStack)
     {
-        return new ShapelessOreRecipe(new ResourceLocation(BloodArsenal.MOD_ID, "guide"), GuideAPI.getStackFromBook(GUIDE_BOOK), Items.BOOK, Items.FLINT_AND_STEEL, RegistrarBloodMagicItems.BLOOD_ORB, FluidUtil.getFilledBucket(new FluidStack(BlockLifeEssence.getLifeEssence(), 0))).setRegistryName("bloodarsenal_guide");
+        return new ShapelessOreRecipe(new ResourceLocation(BloodArsenal.MOD_ID, "guide"), GuideAPI.getStackFromBook(buildBook()), Items.BOOK, Items.FLINT_AND_STEEL, RegistrarBloodMagicItems.BLOOD_ORB, FluidUtil.getFilledBucket(new FluidStack(BlockLifeEssence.getLifeEssence(), 0))).setRegistryName("bloodarsenal_guide");
     }
 }

--- a/src/main/java/arcaratus/bloodarsenal/compat/guideapi/GuideBloodArsenal.java
+++ b/src/main/java/arcaratus/bloodarsenal/compat/guideapi/GuideBloodArsenal.java
@@ -25,6 +25,8 @@ import java.awt.*;
 @GuideBook(priority = EventPriority.HIGHEST)
 public class GuideBloodArsenal implements IGuideBook
 {
+    public static Book GUIDE_BOOK;
+
     @Nullable
     @Override
     public Book buildBook()
@@ -36,12 +38,12 @@ public class GuideBloodArsenal implements IGuideBook
         binder.setAuthor("guide.bloodarsenal.author");
         binder.setColor(new Color(119, 0, 0));
         binder.addCategory(new CategoryItemStack(CategoryLifebringer.buildCategory(), "guide.bloodarsenal.category.lifebringer", EnumBaseTypes.BLOOD_INFUSED_IRON_INGOT.getStack()));
-        return binder.build();
+        return GUIDE_BOOK = binder.build();
     }
 
     @Override
     public IRecipe getRecipe(@Nonnull ItemStack bookStack)
     {
-        return new ShapelessOreRecipe(new ResourceLocation(BloodArsenal.MOD_ID, "guide"), GuideAPI.getStackFromBook(buildBook()), Items.BOOK, Items.FLINT_AND_STEEL, RegistrarBloodMagicItems.BLOOD_ORB, FluidUtil.getFilledBucket(new FluidStack(BlockLifeEssence.getLifeEssence(), 0))).setRegistryName("bloodarsenal_guide");
+        return new ShapelessOreRecipe(new ResourceLocation(BloodArsenal.MOD_ID, "guide"), GuideAPI.getStackFromBook(GUIDE_BOOK), Items.BOOK, Items.FLINT_AND_STEEL, RegistrarBloodMagicItems.BLOOD_ORB, FluidUtil.getFilledBucket(new FluidStack(BlockLifeEssence.getLifeEssence(), 0))).setRegistryName("bloodarsenal_guide");
     }
 }


### PR DESCRIPTION
GuideAPI deprecated Book in favor of BookBinder, as they plan on making Book creation package private and using BookBinder as a factory for it.
I tested the recipes and reading the book, and it all still works properly.