### PR TITLE
Fix issue with infusion ritual only running once

### DIFF
--- a/src/main/java/arcaratus/bloodarsenal/ritual/RitualInfusion.java
+++ b/src/main/java/arcaratus/bloodarsenal/ritual/RitualInfusion.java
@@ -143,7 +143,7 @@ public class RitualInfusion extends RitualBloodArsenal
 
                     tickCrafting(world, pos, network);
 
-                    if (craftingTimer == recipe.getLpCost() * (level + 1) / getRefreshCost())
+                    if (craftingTimer >= recipe.getLpCost() * (level + 1) / getRefreshCost())
                     {
                         modifiable.applyModifier(ModifierHelper.getModifierAndTracker(modifierKey, level));
                         if (trackerFlag)
@@ -172,7 +172,7 @@ public class RitualInfusion extends RitualBloodArsenal
                 {
                     tickCrafting(world, pos, network);
 
-                    if (craftingTimer == recipe.getLpCost() / getRefreshCost())
+                    if (craftingTimer >= recipe.getLpCost() / getRefreshCost())
                     {
                         shrinkItemStackInputs(world, pos, constructItemStackList(recipe.getInputs(), inputStacks), ItemStack.EMPTY);
                         altarInv.setInventorySlotContents(0, recipe.getOutput());
@@ -217,6 +217,8 @@ public class RitualInfusion extends RitualBloodArsenal
         List<TileStasisPlate> stasisPlates = getStasisPlates(world, pos);
         setStasisPlates(world, stasisPlates, false);
         mrs.setActive(false);
+        isCrafting = false;
+        craftingTimer = 0;
     }
 
     private boolean checkStructure(World world, BlockPos pos)


### PR DESCRIPTION
Set timer to 0 on end to prevent next activation from endlessly draining life essence with no end. Also added check for greater than or equal to required essence to prevent issue in future.