### PR TITLE
Fix Glass Sacrificial Dagger bypassing death events

### DIFF
--- a/src/main/java/arcaratus/bloodarsenal/item/tool/ItemGlassSacrificialDagger.java
+++ b/src/main/java/arcaratus/bloodarsenal/item/tool/ItemGlassSacrificialDagger.java
@@ -89,16 +89,19 @@ public class ItemGlassSacrificialDagger extends Item implements IMeshProvider
         if (evt.shouldDrainHealth)
         {
             player.hurtResistantTime = 0;
-            player.attackEntityFrom(DamageSourceGlass.INSTANCE, 0.001F);
-            player.setHealth(Math.max(player.getHealth() - (float) (ConfigHandler.values.glassSacrificialDaggerHealth + itemRand.nextInt(3)), 0.0001F));
-
-            if (!player.isPotionActive(RegistrarBloodArsenal.BLEEDING) && itemRand.nextBoolean())
-                player.addPotionEffect(new PotionEffect(RegistrarBloodArsenal.BLEEDING, 40 + (itemRand.nextInt(4) * 20), itemRand.nextInt(2)));
-
-            if (player.getHealth() <= 0.001F)
+            float nextHitDmg = (float)(ConfigHandler.values.glassSacrificialDaggerHealth + itemRand.nextInt(3)
+            if (Math.ceil(player.getHealth() - nextHitDmg) <= 0)
             {
-                player.onDeath(DamageSourceGlass.INSTANCE);
-                player.setHealth(0);
+                player.attackEntityFrom(DamageSourceGlass.INSTANCE, Float.MAX_VALUE);
+            } else
+            {
+                player.attackEntityFrom(DamageSourceGlass.INSTANCE, 0.001F);
+                float damageAmount = net.minecraftforge.common.ForgeHooks.onLivingDamage(player, damageSrc, nextHitDmg);
+                player.getCombatTracker().trackDamage(damageSrc, player.getHealth(), damageAmount);
+                player.setHealth(Math.max(player.getHealth() - nextHitDmg), 0.001F));
+                
+                if (!player.isPotionActive(RegistrarBloodArsenal.BLEEDING) && itemRand.nextBoolean())
+                    player.addPotionEffect(new PotionEffect(RegistrarBloodArsenal.BLEEDING, 40 + (itemRand.nextInt(4) * 20), itemRand.nextInt(2)));
             }
         }
 

--- a/src/main/java/arcaratus/bloodarsenal/item/tool/ItemGlassSacrificialDagger.java
+++ b/src/main/java/arcaratus/bloodarsenal/item/tool/ItemGlassSacrificialDagger.java
@@ -89,19 +89,20 @@ public class ItemGlassSacrificialDagger extends Item implements IMeshProvider
         if (evt.shouldDrainHealth)
         {
             player.hurtResistantTime = 0;
-            float nextHitDmg = (float)(ConfigHandler.values.glassSacrificialDaggerHealth + itemRand.nextInt(3)
+            float nextHitDmg = (float)(ConfigHandler.values.glassSacrificialDaggerHealth + itemRand.nextInt(3));
             if (Math.ceil(player.getHealth() - nextHitDmg) <= 0)
             {
                 player.attackEntityFrom(DamageSourceGlass.INSTANCE, Float.MAX_VALUE);
             } else
             {
                 player.attackEntityFrom(DamageSourceGlass.INSTANCE, 0.001F);
-                float damageAmount = net.minecraftforge.common.ForgeHooks.onLivingDamage(player, damageSrc, nextHitDmg);
-                player.getCombatTracker().trackDamage(damageSrc, player.getHealth(), damageAmount);
-                player.setHealth(Math.max(player.getHealth() - nextHitDmg), 0.001F));
+                float damageAmount = net.minecraftforge.common.ForgeHooks.onLivingDamage(player, DamageSourceGlass.INSTANCE, nextHitDmg);
+                player.getCombatTracker().trackDamage(DamageSourceGlass.INSTANCE, player.getHealth(), damageAmount);
+                player.setHealth(Math.max(player.getHealth() - nextHitDmg, 0.001F));
                 
                 if (!player.isPotionActive(RegistrarBloodArsenal.BLEEDING) && itemRand.nextBoolean())
                     player.addPotionEffect(new PotionEffect(RegistrarBloodArsenal.BLEEDING, 40 + (itemRand.nextInt(4) * 20), itemRand.nextInt(2)));
+
             }
         }
 


### PR DESCRIPTION
Used 1.12 Blood Magic's Sacrifical Dagger as reference:
["Possible fix to (many of the) abnormal death events concerning the sacrificial Dagger (#1554)"](https://github.com/WayofTime/BloodMagic/commit/572d8eff4f44bfc89e7f4b6219b03a5b4d58dac8)
Tested with draconic evolution draconic armor, astral sorcery phoenix blessing, avaritia infinity armor, blood magic's living armor's grim reaper's sprint upgrade, and corail tombstone. All latest versions of the mods on 1.12.
Test results: Draconic armor now dies like it does with the blood magic dagger. Phoenix blessing, grim reaper's sprint, and infinity armor revive you instead of dying and leaving no grave behind.
**This fixes graves being lost when dying to the glass sacrificial dagger while having revive abilities.**